### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const nodemailer = require('nodemailer');
 const nodemailerSesTransport = require('nodemailer-ses-transport');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const async = require('async');
 const fs = require('fs');
 const htmlToText = require('html-to-text');

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "handlebars": "^4.0.5",
     "handlebars-helpers": "^0.7.3",
     "html-to-text": "^2.1.0",
-    "node-uuid": "^1.4.7",
     "nodemailer": "^2.3.0",
     "nodemailer-dkim": "^1.0.4",
-    "nodemailer-ses-transport": "^1.3.0"
+    "nodemailer-ses-transport": "^1.3.0",
+    "uuid": "^3.0.0"
   },
   "devconfig": {
     "paths": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.